### PR TITLE
Some resemblance of a REST API

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -135,6 +135,54 @@ void httpServer(int port, C1231LR::Settings *card)
 		svr.stop();
 	});
 
+	// REST API
+	svr.Get("/api/v1/cards", [&card](const httplib::Request &, httplib::Response &res) {
+		res.set_content(generateCardListJSON(card->cardPath), "application/json");
+	});
+
+	svr.Get("/api/v1/insertedCard", [&card](const httplib::Request &, httplib::Response &res) {
+		res.set_content(" { \"cardName\":\"" + card->cardName + "\", \"inserted\":" + (card->insertedCard ? "true" : "false") + " }", "application/json");
+	});
+
+	svr.Post("/api/v1/insertedCard", [&card](const httplib::Request &req, httplib::Response &res) {
+		card->insertedCard = true;
+		if (req.has_param("cardname")) {
+			card->cardName = req.get_param_value("cardname");
+		}
+		res.set_content(" { \"cardName\":\"" + card->cardName + "\", \"inserted\":" + (card->insertedCard ? "true" : "false") + " }", "application/json");
+	});
+
+	svr.Delete("/api/v1/insertedCard", [&card](const httplib::Request &, httplib::Response &res) {
+		card->insertedCard = false;
+		res.set_content("null", "application/json");
+	});
+
+	svr.Get("/api/v1/dispenser", [&card](const httplib::Request &, httplib::Response &res) {
+		if (card->reportDispenserEmpty == true) {
+			res.set_content("empty", "text/plain");
+		} else {
+			res.set_content("full", "text/plain");
+		}
+	});
+
+	svr.Post("/api/v1/dispenser", [&card](const httplib::Request &, httplib::Response &res) {
+		card->reportDispenserEmpty = false;
+		if (card->reportDispenserEmpty == true) {
+			res.set_content("empty", "text/plain");
+		} else {
+			res.set_content("full", "text/plain");
+		}
+	});
+
+	svr.Delete("/api/v1/dispenser", [&card](const httplib::Request &, httplib::Response &res) {
+		card->reportDispenserEmpty = true;
+		if (card->reportDispenserEmpty == true) {
+			res.set_content("empty", "text/plain");
+		} else {
+			res.set_content("full", "text/plain");
+		}
+	});
+
 	svr.listen("0.0.0.0", port);
 }
 


### PR DESCRIPTION
Here you go, some resemblance of a proper REST API:

* Everything is in `/api/v1`
* Reports 200 OK with relevant data on requests (errors etc handled by libhttp mostly it seems)
* relevant GET/POST/DELETE methods used for controlling internals of the emulator:
  * GET = report status
  * POST = set value/turn on
  * DELETE = unset value/turn off

Endpoints:
* `/dispenser` - POST sets it to full, DELETE to empty, responds with plaintext "empty" or "full", GET yields current status
* `/insertedCard` - POST sets it to card present, optionally `?cardname=...` argument to set loaded card, DELETE sets it to card empty (doesn't update card name), GET yields current status (both cardname and inserted status)
* `/cards` - same as old `/actions?list`

Future thoughts:
* Add endpoints for fetching raw card data?
* Add endpoint that fetches general status of emulator that has all the stuff in one place?

P.S. I'm a complete noob in C(++), excuse the bad code/copypaste.
P.P.S. DB9 breakout adapters finally arrived, will be testing emulator this weekend hopefully.
