### PR TITLE
hasCard, waitingForCard statuses exposed over API + some logging

### DIFF
--- a/Includes/C1231LR.cpp
+++ b/Includes/C1231LR.cpp
@@ -30,6 +30,7 @@ void C1231LR::UpdateRStatus()
 	// We "grab" the card for the user
 	if (localStatus == CardPosition::POS_EJECTED_NOT_REMOVED) {
 		cardSettings.insertedCard = false;
+		cardSettings.hasCard = false;
 		MoveCard(MovePositions::NO_CARD);
 	}
 
@@ -74,18 +75,23 @@ void C1231LR::MoveCard(CardIo::MovePositions position)
 	switch (position) {
 		case MovePositions::NO_CARD:
 			localStatus = CardPosition::NO_CARD;
+			cardSettings.hasCard = false;
 			break;
 		case MovePositions::READ_WRITE_HEAD:
 			localStatus = CardPosition::POS_MAG;
+			cardSettings.hasCard = true;
 			break;
 		case MovePositions::THERMAL_HEAD:
 			localStatus = CardPosition::POS_THERM;
+			cardSettings.hasCard = true;
 			break;
 		case MovePositions::DISPENSER_THERMAL:
 			localStatus = CardPosition::POS_THERM_DISP;
+			cardSettings.hasCard = true;
 			break;
 		case MovePositions::EJECT:
 			localStatus = CardPosition::POS_EJECTED_NOT_REMOVED;
+			cardSettings.hasCard = false;
 			break;
 		default:
 			break;

--- a/Includes/C1231LR.cpp
+++ b/Includes/C1231LR.cpp
@@ -52,8 +52,10 @@ bool C1231LR::HasCard()
 void C1231LR::DispenseCard()
 {
 	if (localStatus != CardPosition::NO_CARD) {
+		spdlog::info("Error dispensing card - card present?");
 		SetSError(S::ILLEGAL_COMMAND);
 	} else {
+		spdlog::info("Dispensing new card");
 		MoveCard(MovePositions::DISPENSER_THERMAL);
 	}
 }
@@ -61,6 +63,7 @@ void C1231LR::DispenseCard()
 void C1231LR::EjectCard()
 {
 	if (localStatus != CardPosition::NO_CARD) {
+		spdlog::info("Ejecting card");
 		MoveCard(MovePositions::EJECT);
 	}
 }

--- a/Includes/CardIo.cpp
+++ b/Includes/CardIo.cpp
@@ -98,6 +98,8 @@ void CardIo::Command_33_ReadData2()
 			if (mode == static_cast<uint8_t>(Mode::CardCapture)) { // don't reply any card info if we get this
 				if (!HasCard()) {
 					status.s = S::WAITING_FOR_CARD;
+					spdlog::info("Game requests user to insert card");
+					cardSettings.waitingForCard = true;
 					currentStep--;
 				}
 			} else {
@@ -685,6 +687,10 @@ void CardIo::HandlePacket()
 	UpdateRStatus();
 
 	if (runningCommand) { // 20 is a special case, see function
+		if (cardSettings.waitingForCard) {
+			spdlog::info("Game no lnger requests user to insert card");
+			cardSettings.waitingForCard = false;
+		}
 		switch (currentCommand) {
 			case 0x10: Command_10_Initalize(); break;
 			case 0x20: Command_20_ReadStatus(); break;

--- a/Includes/CardIo.h
+++ b/Includes/CardIo.h
@@ -56,6 +56,7 @@ public:
 		std::string cardName{};
 		std::string cardPath{};
 		bool insertedCard{false};
+		bool hasCard{false};
 		bool reportDispenserEmpty{false};
 	};
 

--- a/Includes/CardIo.h
+++ b/Includes/CardIo.h
@@ -57,6 +57,7 @@ public:
 		std::string cardPath{};
 		bool insertedCard{false};
 		bool hasCard{false};
+		bool waitingForCard{false};
 		bool reportDispenserEmpty{false};
 	};
 

--- a/main.cpp
+++ b/main.cpp
@@ -141,7 +141,11 @@ void httpServer(int port, C1231LR::Settings *card)
 	});
 
 	svr.Get("/api/v1/hasCard", [&card](const httplib::Request &, httplib::Response &res) {
-		res.set_content(card->insertedCard ? "true" : "false", "application/json");
+		res.set_content(card->hasCard ? "true" : "false", "application/json");
+	});
+
+	svr.Get("/api/v1/readyCard", [&card](const httplib::Request &, httplib::Response &res) {
+		res.set_content(card->waitingForCard ? "true" : "false", "application/json");
 	});
 
 	svr.Get("/api/v1/insertedCard", [&card](const httplib::Request &, httplib::Response &res) {
@@ -149,7 +153,9 @@ void httpServer(int port, C1231LR::Settings *card)
 	});
 
 	svr.Post("/api/v1/insertedCard", [&card](const httplib::Request &req, httplib::Response &res) {
-		card->insertedCard = true;
+		if (!req.has_param("loadonly")) {
+			card->insertedCard = true;
+		}
 		if (req.has_param("cardname")) {
 			card->cardName = req.get_param_value("cardname");
 		}

--- a/main.cpp
+++ b/main.cpp
@@ -140,6 +140,10 @@ void httpServer(int port, C1231LR::Settings *card)
 		res.set_content(generateCardListJSON(card->cardPath), "application/json");
 	});
 
+	svr.Get("/api/v1/hasCard", [&card](const httplib::Request &, httplib::Response &res) {
+		res.set_content(card->insertedCard ? "true" : "false", "application/json");
+	});
+
 	svr.Get("/api/v1/insertedCard", [&card](const httplib::Request &, httplib::Response &res) {
 		res.set_content(" { \"cardName\":\"" + card->cardName + "\", \"inserted\":" + (card->insertedCard ? "true" : "false") + " }", "application/json");
 	});

--- a/main.cpp
+++ b/main.cpp
@@ -135,6 +135,54 @@ void httpServer(int port, C1231LR::Settings *card)
 		svr.stop();
 	});
 
+	// REST API
+	svr.Get("/api/v1/cards", [&card](const httplib::Request &, httplib::Response &res) {
+		res.set_content(generateCardListJSON(card->cardPath), "application/json");
+	});
+
+	svr.Get("/api/v1/insertedCard", [&card](const httplib::Request &, httplib::Response &res) {
+		res.set_content(" { \"cardName\":\"" + card->cardName + "\", \"inserted\":" + (card->insertedCard ? "true" : "false") + " }", "application/json");
+	});
+
+	svr.Post("/api/v1/insertedCard", [&card](const httplib::Request &req, httplib::Response &res) {
+		card->insertedCard = true;
+		if (req.has_param("cardname")) {
+			card->cardName = req.get_param_value("cardname");
+		}
+		res.set_content(" { \"cardName\":\"" + card->cardName + "\", \"inserted\":" + (card->insertedCard ? "true" : "false") + " }", "application/json");
+	});
+
+	svr.Delete("/api/v1/insertedCard", [&card](const httplib::Request &, httplib::Response &res) {
+		card->insertedCard = false;
+		res.set_content("null", "application/json");
+	});
+
+	svr.Get("/api/v1/dispenser", [&card](const httplib::Request &, httplib::Response &res) {
+		if (card->reportDispenserEmpty == true) {
+			res.set_content("empty", "text/plain");
+		} else {
+			res.set_content("full", "text/plain");
+		}
+	});
+
+	svr.Post("/api/v1/dispenser", [&card](const httplib::Request &, httplib::Response &res) {
+		card->reportDispenserEmpty = false;
+		if (card->reportDispenserEmpty == true) {
+			res.set_content("empty", "text/plain");
+		} else {
+			res.set_content("full", "text/plain");
+		}
+	});
+
+	svr.Delete("/api/v1/dispenser", [&card](const httplib::Request &, httplib::Response &res) {
+		card->reportDispenserEmpty = true;
+		if (card->reportDispenserEmpty == true) {
+			res.set_content("empty", "text/plain");
+		} else {
+			res.set_content("full", "text/plain");
+		}
+	});
+
 	svr.listen("0.0.0.0", port);
 }
 


### PR DESCRIPTION
I cannot into C++, tried passing `cardHandler` and using its `HasCard()` directly but i don't know C++ enough to make it work, therefore I just added `hasCard` variable/property into `CardIO::Settings` that is only updated via moving card. Similarly added `waitingForCard` to show whether card reader is in `WAITING_FOR_CARD` mode, might be a bit janky since i'm not entirely sure when it's supposed to be reset, but seems to be working on WMMT3DX+ at least.

`POST insertedCard` now also has `loadonly` parameter so that you can tell emulator to load specific file without "inserting" it - this way you can prime the emulator to writing into specific file while game creates new card, trying to forcefully "insert" a card while game tries to make new card will result in error.

Also adds some logging to see what's going on with emulator without having to enable debugging/poll the API.

Fixes #12 and #13